### PR TITLE
Add PHP 7.4 support.

### DIFF
--- a/4-php74/Dockerfile
+++ b/4-php74/Dockerfile
@@ -1,0 +1,12 @@
+FROM php:7.4-apache
+
+RUN apt-get update -y && apt-get install -y sendmail libpng-dev libtidy-dev libfreetype6-dev libjpeg62-turbo-dev zlib1g-dev libicu-dev g++ libxml2-dev libonig-dev
+RUN docker-php-ext-configure gd --enable-gd --with-freetype --with-jpeg
+RUN docker-php-ext-configure intl
+RUN docker-php-ext-install -j$(nproc) gd mysqli tidy intl ctype dom fileinfo mbstring session simplexml tokenizer xml
+RUN a2enmod rewrite
+RUN a2enmod headers
+RUN a2enmod expires
+
+COPY php.ini /usr/local/etc/php/
+COPY server-signature.conf /etc/apache2/conf-enabled/

--- a/4-php74/php.ini
+++ b/4-php74/php.ini
@@ -1,0 +1,6 @@
+date.timezone = America/Edmonton
+log_errors = On
+error_log = /dev/stderr
+memory_limit = 512M
+upload_max_filesize = 100M
+post_max_size = 100M

--- a/4-php74/server-signature.conf
+++ b/4-php74/server-signature.conf
@@ -1,0 +1,2 @@
+ServerTokens Prod
+ServerSignature Off


### PR DESCRIPTION
- As of PHP 7.4.0, the Hash extension is a core PHE extension, so it is always enabled
- libonig-dev package required for mbstring extension
- Interface for docker-php-ext-configure gd changed.