### PR TITLE
Add webp support to SS3 image.

### DIFF
--- a/3/Dockerfile
+++ b/3/Dockerfile
@@ -1,7 +1,7 @@
 FROM php:5.6-apache
 
-RUN apt-get update -y && apt-get install -y sendmail libpng-dev libtidy-dev libfreetype6-dev libjpeg62-turbo-dev
-RUN docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/
+RUN apt-get update -y && apt-get install -y sendmail libpng-dev libtidy-dev libfreetype6-dev libjpeg62-turbo-dev libvpx-dev libwebp-dev
+RUN docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ --with-webp-dir=/usr/include/ --with-vpx-dir=/usr/include/
 RUN docker-php-ext-install gd mysql mysqli tidy
 RUN a2enmod rewrite
 RUN a2enmod headers


### PR DESCRIPTION
- PHP 5.6 needs libvpx-dev and libwebp-dev installed
- configure gd --with-webp-dir and --with-vpx-dir